### PR TITLE
In __getHotDotState(...) raplace __getNodeByNodeId(...) by __getNodeByNodeData(...)

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -793,7 +793,7 @@
         this.__getHotDotState = function (stateId, dom, node) {
             if (!!!node) {
                 if (!!dom) {
-                    node = this.__getNodeByNodeId($(dom).attr('nodeId'))
+                    node = this.__getNodeByNodeData($(dom).attr('nodeId'))
                 }
             }
 


### PR DESCRIPTION
This fixes the bug where the timeline can't get the hot node state correctly, because of being unable to return the right node.  The reason for this was the use of __getNodeByNodeId(...) instead of __getNodeByNodeData(...).

Example of the problem this would cause *before* bugfix:
If a particular node has an individual "state" set (e.g. bigger radius than default nodes), and the user hovers over the node and then removes the mouse - the node will set back to the *default* state (e.g. return to the default, smaller node size, instead of returning to the bigger radius defined for the individual node).